### PR TITLE
add support for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,18 @@ Also note, these scripts look for/put configs/logs in non-standard directories:
 
 These are defined as variables at the top of the provided scripts.
 
+### MacOS launchd
+* `launchd/name.neuhalfen.msmtpq-watcher.plist` - launchd service that watches the spool directory
+
 ## Install:
 
 This is a highly simplified script assuming you already have the above-mentioned 
 msmtp config file and set up XDG variables.
 
+
+### Linux
 ```
-git clone https://github.com/Stebalien/msmtp-queue.git /tmp/msmtpq
+git clone https://github.com/neuhalje/msmtp-queue.git /tmp/msmtpq
 sudo cp /tmp/msmtpq/msmtpq* /usr/local/bin
 mkdir -p ~/.config/systemd/user $XDG_DATA_HOME/mail.queue
 cp /tmp/msmtpq/systemd/msmtp-queue.* ~/.config/systemd/user
@@ -44,6 +49,25 @@ systemctl --user enable msmtp-queue.path msmtp-queue.timer
 ```
 Afterwards, update your mutt configuration to use msmtpq instead of msmtp.
 
+### MacOS
+MacOS needs a current bash from homebrew, else the stone age bash (3.x) from MacOS will err on the scripts.
+
+```
+brew install flock bash msmtp
+
+git clone https://github.com/neuhalje/msmtp-queue.git /tmp/msmtpq
+sudo cp /tmp/msmtpq/msmtpq* /usr/local/bin
+mkdir -p ~/.config/systemd/user $XDG_DATA_HOME/mail.queue
+
+cp launchd/*  ~/Library/LaunchAgents/
+
+launchctl unload ~/Library/LaunchAgents/name.neuhalfen.msmtpq-watcher.plist 
+launchctl load ~/Library/LaunchAgents/name.neuhalfen.msmtpq-watcher.plist 
+launchctl start name.neuhalfen.msmtpq-watcher
+```
+
+
+Afterwards, update your mutt configuration to use msmtpq instead of msmtp.
 ---
 
 WHY? Because it's pretty much-bullet proof and the default scripts were NIH.

--- a/launchd/name.neuhalfen.msmtpq-watcher.plist
+++ b/launchd/name.neuhalfen.msmtpq-watcher.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>name.neuhalfen.msmtpq-watcher</string>
+    <!--
+        ServiceDescription seems to be unsupported but I will keep it here
+        to boldly state what nobody wants to see: what this does
+    -->
+    <key>ServiceDescription</key>
+    <string>msmtpq - Queue Watcher</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+    <key>Program</key>
+    <string>/usr/local/bin/msmtpq-flush</string>
+    <key>QueueDirectories</key>
+    <array>
+      <string>~/.local/share/mail.queue</string>
+    </array>
+    <!-- Do not run more often than every X seconds -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+  </dict>
+</plist>

--- a/msmtpq
+++ b/msmtpq
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
+
 
 QUEUE_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/mail.queue"
 
@@ -26,8 +27,14 @@ cat > "$TMP_DIR/message"
 
 while [[ -d "$TMP_DIR" ]]; do
     MESSAGE_DIR="$(date +"$HOSTNAME-%s%N-P$$.mail")"
+    #
     # Atomic rename.
-    mv -n -T "$TMP_DIR" "$QUEUE_DIR/$MESSAGE_DIR"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # must use gnu mv for -T
+       gmv -n -T "$TMP_DIR" "$QUEUE_DIR/$MESSAGE_DIR"
+    else
+       mv -n -T "$TMP_DIR" "$QUEUE_DIR/$MESSAGE_DIR"
+    fi
 done
 
 trap - EXIT

--- a/msmtpq-flush
+++ b/msmtpq-flush
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 shopt -s nullglob
@@ -6,6 +6,10 @@ shopt -s nullglob
 CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/msmtp/config"
 QUEUE_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/mail.queue"
 LOG="${XDG_LOG_HOME:-$HOME/.local/log}/msmtp.log"
+
+# Like it or not, sometimes the wrong bash version or the wrong path
+# will bite you harder than you'd like to admit
+echo "Started on bash ${BASH_VERSION} with PATH ${PATH}" >>${LOG}
 
 exec {stdout}>&1
 coproc logger {(while read line; do echo "$(date -Iseconds) $line"; done >>"$LOG";); }
@@ -39,7 +43,13 @@ if ! lock -n -x "$QUEUE_DIR"; then
     exit 0
 fi
 
-if ! ping -qnc1 -w4 example.com >/dev/null 2>&1; then
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    PING="ping -qnc1 -t4 example.com"
+else
+    PING="ping -qnc1 -w4 example.com"
+fi
+
+if ! ${PING} >/dev/null 2>&1; then
     echo "Not Online"
     exit 0
 fi
@@ -61,10 +71,25 @@ for mail in "$QUEUE_DIR"/*.mail/; do
         continue
     fi
 
-    prefix="$prefix [ $(xargs -0 -a "$mail/msmtp_flags" printf '%s ')]"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        # macos xargs has no --arg-file option
+        args="$(xargs -0  printf '"%s" '<"$mail/msmtp_flags")"
+        prefix="$prefix [ ${args}]"
 
-    echo "$prefix sending"
-    xargs -0 -a "$mail/msmtp_flags" msmtp -C "$CONFIG" -X - < "$mail/message"
+        echo "$prefix sending"
+
+        # -X will swallow the next argument with msmtp version 1.8.24 on macos
+        # so it is dropped and we use the regular logfile
+        # Also, the missing xargs --arg-file .
+        command="msmtp -C "$CONFIG" ${args}"
+        eval ${command}  < "$mail/message"
+    else
+        prefix="$prefix [ $(xargs -0 -a "$mail/msmtp_flags" printf '%s ')]"
+
+        echo "$prefix sending"
+        xargs -0 -a "$mail/msmtp_flags" msmtp -C "$CONFIG" -X - < "$mail/message"
+    fi
+
     ret="$?"
     if [[ ! "$ret" -eq 0 ]] ; then
         echo "$prefix faild to send; msmtp rc = $ret"


### PR DESCRIPTION
- depends on homebrew (flock, up-to-date bash)
- add launchd background service
- evil hack with `eval` because `xargs` on macos cannot read from files

CAVE: if you would accept, I would add update the `git clone` URL to point to yours as well