### PR TITLE
script to list contents of `$QUEUE_DIR`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,18 @@
 * `msmtpq` is a drop-in replacement for `msmtp` to queue an outgoing
   message. It never blocks and never actually sends messages.
 * `msmtpq-flush` sends reliably queued messages.
+* `msmtpq-queue` shows information about queued messages.
 
 ## To use:
 
 1. Send messages with `msmtpq` instead of `msmtp`.
 2. Install and enable the provided systemd units to automatically flush queued
    messages.
+3. Use `msmtmpq-queue` to see information about the messages.
+   - `-h` help / usage
+   - `-c` print count of queued messages and exit
+   - `-f` include the full message file path
+
    
 ## Systemd Units:
 

--- a/msmtpq-queue
+++ b/msmtpq-queue
@@ -24,10 +24,9 @@ the msmtpq-queue QUEUE_DIR.
 
 Usage:
 
-  -c    # print the count and exit
-  -p    # include the full message file path
   -h    # this help
-
+  -c    # print count of queued messages and exit
+  -p    # include the full message file path
 "
 
 COUNT_ONLY=0

--- a/msmtpq-queue
+++ b/msmtpq-queue
@@ -55,7 +55,7 @@ shift $((OPTIND-1))
 
 # This script shows the contents of the msmtpq queue directory
 
-QUEUE_COUNT=$(ls -A "$QUEUE_DIR" | wc -l)
+QUEUE_COUNT=$(ls -1qA "$QUEUE_DIR" | wc -l)
 
 [[ $COUNT_ONLY -eq 1 ]] && echo "$QUEUE_COUNT" && exit 0
 
@@ -67,7 +67,6 @@ for msg in "$QUEUE_DIR"/*/message; do
   echo '---'
   msgid=$(dirname "$msg" | xargs basename)
   echo "msg: $msgid"
-  grep -E '^(From|To|Subject):' "$msg" | sed 's/^/  /'
+  sed -n 's/^\(From\|To\|Subject\):/  &/p' "$msg"
   [[ $SHOW_FILE_PATH -eq 1 ]] && echo "  file: $msg"
 done
-

--- a/msmtpq-queue
+++ b/msmtpq-queue
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+QUEUE_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/mail.queue"
+
+[[ -d "$QUEUE_DIR" ]] || mkdir -m0700 -p "$QUEUE_DIR"
+
+if [[ ! -w "$QUEUE_DIR" ]]; then
+    echo "Insufficient privileges to write to queue."
+    exit 1
+fi
+  
+if [[ ! -r "$QUEUE_DIR" ]]; then
+    echo "Insufficient privileges to read from queue."
+    exit 1
+fi
+
+HELP_TEXT="
+msmtpq-queue shows information about queued messages in
+the msmtpq-queue QUEUE_DIR.
+
+  current value: $QUEUE_DIR
+
+Usage:
+
+  -c    # print the count and exit
+  -p    # include the full message file path
+  -h    # this help
+
+"
+
+COUNT_ONLY=0
+SHOW_FILE_PATH=0
+# read in the options
+while getopts "cph" o; do
+    case "${o}" in
+        h)
+          # show help
+          echo "$HELP_TEXT"
+          exit 0
+          ;;
+        c)
+          COUNT_ONLY=1
+          ;;
+        p)
+          SHOW_FILE_PATH=1
+          ;;
+        *)
+          echo "$HELP_TEXT"
+          exit 1
+          ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# This script shows the contents of the msmtpq queue directory
+
+QUEUE_COUNT=$(ls -A "$QUEUE_DIR" | wc -l)
+
+[[ $COUNT_ONLY -eq 1 ]] && echo "$QUEUE_COUNT" && exit 0
+
+[[ $QUEUE_COUNT -eq 0 ]] && echo "no messages queued" && exit 0
+
+echo "$QUEUE_COUNT messages queued"
+
+for msg in "$QUEUE_DIR"/*/message; do
+  echo '---'
+  msgid=$(dirname "$msg" | xargs basename)
+  echo "msg: $msgid"
+  grep -E '^(From|To|Subject):' "$msg" | sed 's/^/  /'
+  [[ $SHOW_FILE_PATH -eq 1 ]] && echo "  file: $msg"
+done
+

--- a/msmtpq-queue
+++ b/msmtpq-queue
@@ -10,7 +10,6 @@ if [[ ! -w "$QUEUE_DIR" ]]; then
     echo "Insufficient privileges to write to queue."
     exit 1
 fi
-  
 if [[ ! -r "$QUEUE_DIR" ]]; then
     echo "Insufficient privileges to read from queue."
     exit 1


### PR DESCRIPTION
Thanks for msmtpq-queue. I wanted a script to list the contents of that directory
It's called `msmtpq-queue`.

-  `-h` to show usage
- `-c` to return only the message count and exit
- `-f` to also print the full path to the message file

I am not sure if this of interest for inclusion or if you accept contributions, but thought I'd share.

Cheers.